### PR TITLE
listifying distribution nodes (#7)

### DIFF
--- a/sonormal/__init__.py
+++ b/sonormal/__init__.py
@@ -69,7 +69,13 @@ SO_PROPERTY_ID = f"{SO_}propertyID"
 SO_COMPACT_CONTEXT = {"@context": ["http://schema.org/", {"id": "id", "type": "type"}]}
 
 SO_DATASET_FRAME = {
-    "@context": "http://schema.org/",
+    "@context": {
+      "@vocab":"http://schema.org/",
+      "distribution": {
+            "@id":"distribution",
+            "@container":"@set"
+	    }
+    },
     "@type": "Dataset",
     "identifier": {},
     "creator": {}


### PR DESCRIPTION
Adding functionality to the framing process that coerces items in `"distribution"` nodes to a list regardless of quantity. Requested by @jeanetteclark for the FAIR assessment suite's new schema.org tests.